### PR TITLE
explicitly convert time strings

### DIFF
--- a/layouts/partials/info/basic.html
+++ b/layouts/partials/info/basic.html
@@ -12,8 +12,8 @@
           </h2>
           <h3 class="text-uppercase pb-5">
             <b>
-              {{ $startDate := .Param "dateStart" }}
-              {{ $endDate := .Param "dateEnd" }}
+              {{ $startDate := .Param "dateStart" | time }}
+              {{ $endDate := .Param "dateEnd" | time }}
               {{ if eq $startDate.Month $endDate.Month }}
                  {{ $startDate.Format "January 2" }}-{{ $endDate.Format "2" -}}
               {{ else }}


### PR DESCRIPTION
When using a yaml config instead of toml, the parameters `dateStart` and `dateStart` are of type `string` instead of `time.Time`. 
That causes the rendering to fail:
```
failed to render pages: render of "home" failed: execute of template failed: template: index.html:32:5: executing "main" at <partial "info/basic.html" .>: error calling partial: "/website/themes/hugo-hackatheme/layouts/partials/info/basic.html:17:33": execute of template failed: template: partials/info/basic.html:17:33: executing "partials/info/basic.html" at <$startDate.Month>: can't evaluate field Month in type string
```

Added the Hugo [time](https://gohugo.io/functions/time/) function to parse the time string.

Tested with parameters:
```yaml
params:
  dateStart: 2021-07-01T18:00:00+02:00
  dateEnd: 2021-07-03T22:00:00+02:00
  dateForm: "January 2, 2006"
```

